### PR TITLE
Prevents CORS header conflicts with upstream servers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -102,6 +102,10 @@ func (c *CORSConfig) WildcardOriginAllowed() bool {
 	return slices.Contains(c.Origins, "*")
 }
 
+func (c *CORSConfig) HasAnyConfiguration() bool {
+	return len(c.Origins) > 0 || c.Methods != "" || c.Headers != "" || c.Credentials
+}
+
 func validateCORSConfig(corsConfig *CORSConfig) error {
 	hasWildcard := corsConfig.WildcardOriginAllowed()
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -357,6 +357,93 @@ func TestValidateCORSConfig(t *testing.T) {
 	}
 }
 
+func TestCORSConfigHasAnyConfiguration(t *testing.T) {
+	tests := []struct {
+		name       string
+		corsConfig CORSConfig
+		expected   bool
+	}{
+		{
+			name:       "no configuration",
+			corsConfig: CORSConfig{},
+			expected:   false,
+		},
+		{
+			name: "only origins configured",
+			corsConfig: CORSConfig{
+				Origins: []string{"http://localhost:3000"},
+			},
+			expected: true,
+		},
+		{
+			name: "only methods configured",
+			corsConfig: CORSConfig{
+				Methods: "GET, POST",
+			},
+			expected: true,
+		},
+		{
+			name: "only headers configured",
+			corsConfig: CORSConfig{
+				Headers: "Content-Type",
+			},
+			expected: true,
+		},
+		{
+			name: "only credentials enabled",
+			corsConfig: CORSConfig{
+				Credentials: true,
+			},
+			expected: true,
+		},
+		{
+			name: "empty origins slice",
+			corsConfig: CORSConfig{
+				Origins: []string{},
+			},
+			expected: false,
+		},
+		{
+			name: "empty methods string",
+			corsConfig: CORSConfig{
+				Methods: "",
+			},
+			expected: false,
+		},
+		{
+			name: "empty headers string",
+			corsConfig: CORSConfig{
+				Headers: "",
+			},
+			expected: false,
+		},
+		{
+			name: "credentials false",
+			corsConfig: CORSConfig{
+				Credentials: false,
+			},
+			expected: false,
+		},
+		{
+			name: "multiple configurations",
+			corsConfig: CORSConfig{
+				Origins:     []string{"*"},
+				Methods:     "GET, POST",
+				Headers:     "Content-Type",
+				Credentials: true,
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.corsConfig.HasAnyConfiguration()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestServerAddressConfiguration(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/handlers/forward.go
+++ b/handlers/forward.go
@@ -64,6 +64,6 @@ func ForwardHandler(cfg config.Config) http.Handler {
 		timeout := cfg.GetDefaultTimeout()
 
 		slog.Info("Forwarding request", "target_url", targetURL.String(), "method", r.Method, "timeout", timeout)
-		executeProxyRequest(proxyReq, w, timeout)
+		executeProxyRequest(proxyReq, w, timeout, cfg.CORS)
 	})
 }


### PR DESCRIPTION
Prevents CORS header conflicts when upstream servers send their own CORS headers that would override Corsair's configured CORS policy. When Corsair has CORS configured, upstream CORS headers are now filtered out and logged as warnings.