### PR TITLE
fix: Do not add trailing slash on target url

### DIFF
--- a/handlers/proxy.go
+++ b/handlers/proxy.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/bastienwirtz/corsair/config"
+	"github.com/bastienwirtz/corsair/middleware"
 )
 
 // executeProxyRequest executes the HTTP request and copies the response back to the client.
@@ -57,6 +58,13 @@ func executeProxyRequest(proxyReq *http.Request, w http.ResponseWriter, timeout 
 	}
 }
 
+func GetOriginalPath(r *http.Request) string {
+	if v, ok := r.Context().Value(middleware.OriginalPathKey).(string); ok {
+		return v
+	}
+	return r.URL.Path
+}
+
 // ProxyHandler creates an HTTP handler that proxies requests to a configured endpoint.
 func ProxyHandler(endpoint config.Endpoint, cfg config.Config) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -74,7 +82,7 @@ func ProxyHandler(endpoint config.Endpoint, cfg config.Config) http.Handler {
 		}
 
 		// Strip endpoint path and construct target path
-		path := strings.TrimPrefix(r.URL.Path, endpoint.Path)
+		path := strings.TrimPrefix(GetOriginalPath(r), endpoint.Path)
 		if path == "" || path[0] != '/' {
 			path = "/" + path
 		}

--- a/middleware/trailing_slash.go
+++ b/middleware/trailing_slash.go
@@ -1,9 +1,14 @@
 package middleware
 
 import (
+	"context"
 	"net/http"
 	"strings"
 )
+
+type corsContextKey string
+
+const OriginalPathKey corsContextKey = "originalPath"
 
 // TrailingSlash middleware ensures that requests to paths without trailing slashes
 // are internally normalized to have trailing slashes before reaching the router.
@@ -13,21 +18,24 @@ func TrailingSlash() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			path := r.URL.Path
-			
+
 			// Only add trailing slash if:
 			// 1. Path doesn't already end with "/"
 			// 2. Path is not just "/" (root path)
 			// 3. Path doesn't contain a file extension (avoid breaking file requests)
 			if path != "/" && !strings.HasSuffix(path, "/") && !strings.Contains(path[strings.LastIndex(path, "/")+1:], ".") {
+
 				// Create a new URL with trailing slash
 				newURL := *r.URL
 				newURL.Path = path + "/"
-				
+
 				// Update the request URL
 				r.URL = &newURL
 			}
-			
-			next.ServeHTTP(w, r)
+
+			// Store original path in request context so the final target url won't include any added "/"
+			ctx := context.WithValue(r.Context(), OriginalPathKey, path)
+			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -56,11 +56,11 @@ func (h *Handler) registerRoutes() {
 			continue
 		}
 
-		// Ensure path ends with "/" for proper HTTP routing behavior.
+		// Ensure path ends with "/" to be able to handle sub-paths no
+		// matter how the path is configured.
 		// Go's HTTP router treats "/api" and "/api/" differently:
 		// - "/api" matches only exactly "/api"
 		// - "/api/" matches "/api/", "/api/foo", "/api/bar/baz", etc.
-		// This allows our proxy to handle sub-paths correctly.
 		// The trailing slash middleware normalizes incoming requests to
 		// match routes with a ending "/".
 		if !strings.HasSuffix(path, "/") {


### PR DESCRIPTION
Configured routes are registered with a "/" to allow sub path in requests. To allow request without trailing slash to work (and not end up in a redirection), a "/" is automatically added to all incoming url, and so the added  "/"  was forwarded to the destination url, which can cause issues. 

Fixes #6